### PR TITLE
update(UI): トーナメントの画面を追加

### DIFF
--- a/frontend/drizzle.config.ts
+++ b/frontend/drizzle.config.ts
@@ -1,11 +1,16 @@
 import "dotenv/config";
-
+import path from "node:path";
 import { defineConfig } from "drizzle-kit";
+
+const databaseFileName = `file:${path.join(
+  process.env.DB_FILE_DIR ?? "../database",
+  process.env.DB_FILE_NAME ?? "database.db",
+)}`;
 
 export default defineConfig({
   out: "./drizzle/",
   dialect: "sqlite",
   dbCredentials: {
-    url: "file:../database/database.db",
+    url: databaseFileName,
   },
 });

--- a/frontend/src/app/(authed)/dashboard/page.tsx
+++ b/frontend/src/app/(authed)/dashboard/page.tsx
@@ -39,6 +39,13 @@ export default function DashboardPage() {
           >
             ゲームを始める
           </button>
+          <button
+            type="button"
+            className="cyber-button"
+            onClick={() => router.push("/tournament")}
+          >
+            トーナメント
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/app/(authed)/game/page.tsx
+++ b/frontend/src/app/(authed)/game/page.tsx
@@ -64,7 +64,7 @@ export default function Game() {
   }
 
   return (
-    <div className="grid min-h-screen place-items-center">
+    <div className="grid min-h-screen place-items-center pt-18 pb-13">
       <main>
         <CanvasComponent />
       </main>

--- a/frontend/src/app/(authed)/profile/profile.module.css
+++ b/frontend/src/app/(authed)/profile/profile.module.css
@@ -6,7 +6,7 @@
   position: relative;
   overflow: hidden;
   z-index: 5;
-  padding: 100px 20px 20px 20px;
+  padding: 100px 20px 52px 20px;
   width: 100%;
   max-width: 850px;
   margin: 0 auto;

--- a/frontend/src/app/(authed)/tournament/components/TournamentBracket.tsx
+++ b/frontend/src/app/(authed)/tournament/components/TournamentBracket.tsx
@@ -1,0 +1,87 @@
+import { Card } from "./card";
+
+// ダミーデータ
+const dummyMatches = [
+  {
+    id: 1,
+    round: 1,
+    player1: { id: 1, name: "Player1", score: 5 },
+    player2: { id: 2, name: "Player2", score: 3 },
+    winner: 1,
+  },
+  {
+    id: 2,
+    round: 1,
+    player1: { id: 3, name: "Player3", score: 2 },
+    player2: { id: 4, name: "Player4", score: 5 },
+    winner: 4,
+  },
+  {
+    id: 3,
+    round: 2,
+    player1: { id: 1, name: "Player1", score: 5 },
+    player2: { id: 4, name: "Player4", score: 4 },
+    winner: 1,
+  },
+];
+
+export const TournamentBracket = () => {
+  const rounds = Math.max(...dummyMatches.map((match) => match.round));
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="mb-6 text-2xl font-bold text-white">Tournament Bracket</h1>
+      <div className="flex justify-between">
+        {Array.from({ length: rounds }, (_, i) => i + 1).map((round) => (
+          <div key={round} className="flex-1">
+            <h2 className="mb-4 text-xl font-semibold text-white">
+              Round {round}
+            </h2>
+            <div className="space-y-4">
+              {dummyMatches
+                .filter((match) => match.round === round)
+                .map((match) => (
+                  <Card
+                    key={match.id}
+                    className={`p-4 ${
+                      match.winner === match.player1.id
+                        ? "bg-green-900"
+                        : match.winner === match.player2.id
+                          ? "bg-green-900"
+                          : "bg-gray-800"
+                    } text-white`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1">
+                        <div
+                          className={`${
+                            match.winner === match.player1.id
+                              ? "text-green-400"
+                              : ""
+                          }`}
+                        >
+                          {match.player1.name} ({match.player1.score})
+                        </div>
+                        <div
+                          className={`${
+                            match.winner === match.player2.id
+                              ? "text-green-400"
+                              : ""
+                          }`}
+                        >
+                          {match.player2.name} ({match.player2.score})
+                        </div>
+                      </div>
+                      <div className="text-sm text-gray-400">
+                        Match {match.id}
+                      </div>
+                    </div>
+                  </Card>
+                ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/app/(authed)/tournament/components/TournamentButton.tsx
+++ b/frontend/src/app/(authed)/tournament/components/TournamentButton.tsx
@@ -1,0 +1,16 @@
+import { useRouter } from "next/navigation";
+
+import { Button } from "./button";
+
+export const TournamentButton = () => {
+  const router = useRouter();
+
+  return (
+    <Button
+      onClick={() => router.push("/tournament")}
+      className="rounded-lg bg-gradient-to-r from-purple-500 to-pink-500 px-4 py-2 font-bold text-white shadow-lg transition-all duration-300 hover:from-purple-600 hover:to-pink-600"
+    >
+      Tournament
+    </Button>
+  );
+};

--- a/frontend/src/app/(authed)/tournament/components/TournamentLobby.tsx
+++ b/frontend/src/app/(authed)/tournament/components/TournamentLobby.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+
+import { Button } from "./button";
+import { Card } from "./card";
+
+// ダミーデータ
+const dummyTournaments = [
+  {
+    id: 1,
+    name: "Weekend Tournament",
+    participants: 4,
+    maxParticipants: 8,
+    status: "waiting",
+  },
+  {
+    id: 2,
+    name: "Quick Tournament",
+    participants: 8,
+    maxParticipants: 8,
+    status: "starting",
+  },
+];
+
+export const TournamentLobby = () => {
+  const [tournaments, setTournaments] = useState(dummyTournaments);
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-white">Tournament Lobby</h1>
+        <Button
+          onClick={() => {
+            /* TODO: Create new tournament */
+          }}
+          className="bg-green-500 hover:bg-green-600"
+        >
+          Create Tournament
+        </Button>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {tournaments.map((tournament) => (
+          <Card key={tournament.id} className="bg-gray-800 p-4 text-white">
+            <h2 className="mb-2 text-xl font-semibold">{tournament.name}</h2>
+            <p className="text-gray-400">
+              Participants: {tournament.participants}/
+              {tournament.maxParticipants}
+            </p>
+            <p className="mb-4 text-gray-400">Status: {tournament.status}</p>
+            <Button
+              onClick={() => {
+                /* TODO: Join tournament */
+              }}
+              className="w-full bg-blue-500 hover:bg-blue-600"
+              disabled={tournament.participants >= tournament.maxParticipants}
+            >
+              Join Tournament
+            </Button>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/app/(authed)/tournament/components/TournamentResult.tsx
+++ b/frontend/src/app/(authed)/tournament/components/TournamentResult.tsx
@@ -1,0 +1,47 @@
+import { useRouter } from "next/navigation";
+
+import { Button } from "./button";
+import { Card } from "./card";
+
+interface TournamentResultProps {
+  winner: {
+    id: number;
+    name: string;
+    score: number;
+  };
+  isFinal: boolean;
+}
+
+export const TournamentResult = ({
+  winner,
+  isFinal,
+}: TournamentResultProps) => {
+  const router = useRouter();
+
+  return (
+    <div className="container mx-auto flex min-h-screen flex-col items-center justify-center p-4">
+      <Card className="w-full max-w-md bg-gray-800 p-8 text-center text-white">
+        <h1 className="mb-6 text-3xl font-bold">
+          {isFinal ? "Tournament Champion!" : "Match Result"}
+        </h1>
+        <div className="mb-8">
+          <div className="mb-4 text-6xl">🏆</div>
+          <div className="mb-2 text-2xl font-semibold text-green-400">
+            {winner.name}
+          </div>
+          <div className="text-gray-400">Score: {winner.score}</div>
+        </div>
+        {isFinal ? (
+          <Button
+            onClick={() => router.push("/tournament")}
+            className="w-full bg-blue-500 hover:bg-blue-600"
+          >
+            Return to Tournament Lobby
+          </Button>
+        ) : (
+          <div className="text-gray-400">Waiting for next match...</div>
+        )}
+      </Card>
+    </div>
+  );
+};

--- a/frontend/src/app/(authed)/tournament/components/TournamentResult.tsx
+++ b/frontend/src/app/(authed)/tournament/components/TournamentResult.tsx
@@ -1,5 +1,4 @@
-import { useRouter } from "next/navigation";
-
+import { useTournament } from "../context/TournamentContext";
 import { Button } from "./button";
 import { Card } from "./card";
 
@@ -16,7 +15,7 @@ export const TournamentResult = ({
   winner,
   isFinal,
 }: TournamentResultProps) => {
-  const router = useRouter();
+  const { setTournamentState } = useTournament();
 
   return (
     <div className="container mx-auto flex min-h-screen flex-col items-center justify-center p-4">
@@ -33,7 +32,9 @@ export const TournamentResult = ({
         </div>
         {isFinal ? (
           <Button
-            onClick={() => router.push("/tournament")}
+            onClick={() => {
+              setTournamentState("lobby");
+            }}
             className="w-full bg-blue-500 hover:bg-blue-600"
           >
             Return to Tournament Lobby

--- a/frontend/src/app/(authed)/tournament/components/TournamentWaitingRoom.tsx
+++ b/frontend/src/app/(authed)/tournament/components/TournamentWaitingRoom.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+
+import { Button } from "./button";
+import { Card } from "./card";
+
+// ダミーデータ
+const dummyParticipants = [
+  { id: 1, name: "Player1", avatar: "👤" },
+  { id: 2, name: "Player2", avatar: "👤" },
+  { id: 3, name: "Player3", avatar: "👤" },
+  { id: 4, name: "Player4", avatar: "👤" },
+];
+
+export const TournamentWaitingRoom = () => {
+  const [participants, setParticipants] = useState(dummyParticipants);
+  const [chatMessages, setChatMessages] = useState<string[]>([]);
+  const [newMessage, setNewMessage] = useState("");
+
+  const handleSendMessage = () => {
+    if (newMessage.trim()) {
+      setChatMessages([...chatMessages, newMessage]);
+      setNewMessage("");
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {/* 参加者リスト */}
+        <Card className="bg-gray-800 p-4 text-white">
+          <h2 className="mb-4 text-xl font-semibold">Participants</h2>
+          <div className="space-y-2">
+            {participants.map((participant) => (
+              <div
+                key={participant.id}
+                className="flex items-center space-x-2 rounded bg-gray-700 p-2"
+              >
+                <span>{participant.avatar}</span>
+                <span>{participant.name}</span>
+              </div>
+            ))}
+          </div>
+        </Card>
+
+        {/* チャット */}
+        <Card className="bg-gray-800 p-4 text-white md:col-span-2">
+          <h2 className="mb-4 text-xl font-semibold">Chat</h2>
+          <div className="mb-4 h-64 space-y-2 overflow-y-auto">
+            {chatMessages.map((message, index) => (
+              <div key={index} className="rounded bg-gray-700 p-2">
+                {message}
+              </div>
+            ))}
+          </div>
+          <div className="flex space-x-2">
+            <input
+              type="text"
+              value={newMessage}
+              onChange={(e) => setNewMessage(e.target.value)}
+              className="flex-1 rounded bg-gray-700 p-2 text-white"
+              placeholder="Type a message..."
+            />
+            <Button
+              onClick={handleSendMessage}
+              className="bg-blue-500 hover:bg-blue-600"
+            >
+              Send
+            </Button>
+          </div>
+        </Card>
+      </div>
+
+      {/* 開始ボタン */}
+      <div className="mt-4 flex justify-center">
+        <Button
+          onClick={() => {
+            /* TODO: Start tournament */
+          }}
+          className="bg-green-500 px-8 py-2 hover:bg-green-600"
+          disabled={participants.length < 2}
+        >
+          Start Tournament
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/app/(authed)/tournament/components/TournamentWaitingRoom.tsx
+++ b/frontend/src/app/(authed)/tournament/components/TournamentWaitingRoom.tsx
@@ -13,12 +13,12 @@ const dummyParticipants = [
 
 export const TournamentWaitingRoom = () => {
   const [participants, setParticipants] = useState(dummyParticipants);
-  const [chatMessages, setChatMessages] = useState<string[]>([]);
+  const [chatMessages, setChatMessages] = useState<Array<{ id: string; text: string }>>([]);
   const [newMessage, setNewMessage] = useState("");
 
   const handleSendMessage = () => {
     if (newMessage.trim()) {
-      setChatMessages([...chatMessages, newMessage]);
+      setChatMessages([...chatMessages, { id: crypto.randomUUID(), text: newMessage }]);
       setNewMessage("");
     }
   };
@@ -46,9 +46,9 @@ export const TournamentWaitingRoom = () => {
         <Card className="bg-gray-800 p-4 text-white md:col-span-2">
           <h2 className="mb-4 text-xl font-semibold">Chat</h2>
           <div className="mb-4 h-64 space-y-2 overflow-y-auto">
-            {chatMessages.map((message, index) => (
-              <div key={index} className="rounded bg-gray-700 p-2">
-                {message}
+            {chatMessages.map((message) => (
+              <div key={message.id} className="rounded bg-gray-700 p-2">
+                {message.text}
               </div>
             ))}
           </div>

--- a/frontend/src/app/(authed)/tournament/components/button.tsx
+++ b/frontend/src/app/(authed)/tournament/components/button.tsx
@@ -1,0 +1,38 @@
+import { ButtonHTMLAttributes, forwardRef } from "react";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "default" | "primary" | "secondary" | "danger";
+  size?: "sm" | "md" | "lg";
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className = "", variant = "default", size = "md", ...props }, ref) => {
+    const baseStyles =
+      "inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50";
+
+    const variants = {
+      default: "bg-gray-800 text-white hover:bg-gray-700",
+      primary: "bg-blue-600 text-white hover:bg-blue-700",
+      secondary: "bg-gray-600 text-white hover:bg-gray-700",
+      danger: "bg-red-600 text-white hover:bg-red-700",
+    };
+
+    const sizes = {
+      sm: "h-8 px-3 text-sm",
+      md: "h-10 px-4",
+      lg: "h-12 px-6 text-lg",
+    };
+
+    return (
+      <button
+        className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${className}`}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+
+Button.displayName = "Button";
+
+export { Button };

--- a/frontend/src/app/(authed)/tournament/components/card.tsx
+++ b/frontend/src/app/(authed)/tournament/components/card.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, HTMLAttributes } from "react";
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: "default" | "bordered";
+}
+
+const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ className = "", variant = "default", ...props }, ref) => {
+    const baseStyles = "rounded-lg bg-gray-800 text-white";
+
+    const variants = {
+      default: "shadow-lg",
+      bordered: "border border-gray-700",
+    };
+
+    return (
+      <div
+        className={`${baseStyles} ${variants[variant]} ${className}`}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+
+Card.displayName = "Card";
+
+export { Card };

--- a/frontend/src/app/(authed)/tournament/context/README.md
+++ b/frontend/src/app/(authed)/tournament/context/README.md
@@ -1,0 +1,62 @@
+# トーナメントコンテキストの使用方法
+
+## 概要
+トーナメント機能の状態管理を行うための Context API を使用したカスタムプロバイダーです。
+
+## 主な機能
+
+### 状態管理
+- `tournamentState`: 現在のトーナメント画面の状態（lobby | waiting | bracket | result）
+- `currentTournament`: 現在参加しているトーナメントのID
+
+### 提供される関数
+
+#### 基本的な状態変更
+- `setTournamentState(state)`: トーナメント状態を直接設定
+- `setCurrentTournament(id)`: 現在のトーナメントIDを設定
+
+#### トーナメント操作
+- `joinTournament(tournamentId)`: トーナメントに参加（待機室へ遷移）
+- `leaveTournament()`: トーナメントから退出（ロビーへ戻る）
+
+#### 画面遷移
+- `goToLobby()`: ロビー画面へ遷移
+- `goToWaitingRoom()`: 待機室へ遷移
+- `goToBracket()`: ブラケット画面へ遷移
+- `goToResult()`: 結果画面へ遷移
+
+## 使用例
+
+### 子コンポーネントでの使用
+
+```typescript
+import { useTournament } from "../context/TournamentContext";
+
+export function MyComponent() {
+  const { 
+    tournamentState, 
+    joinTournament, 
+    leaveTournament 
+  } = useTournament();
+
+  const handleJoin = () => {
+    joinTournament(123); // トーナメントID 123 に参加
+  };
+
+  const handleLeave = () => {
+    leaveTournament(); // トーナメントから退出
+  };
+
+  return (
+    <div>
+      <p>現在の状態: {tournamentState}</p>
+      <button onClick={handleJoin}>参加</button>
+      <button onClick={handleLeave}>退出</button>
+    </div>
+  );
+}
+```
+
+## 注意事項
+- `useTournament()` フックは必ず `TournamentProvider` の内部で使用してください
+- プロバイダーの外で使用するとエラーが発生します

--- a/frontend/src/app/(authed)/tournament/context/TournamentContext.tsx
+++ b/frontend/src/app/(authed)/tournament/context/TournamentContext.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { createContext, useContext, useState } from "react";
+
+export type TournamentState = "lobby" | "waiting" | "bracket" | "result";
+
+interface TournamentContextType {
+  tournamentState: TournamentState;
+  setTournamentState: (state: TournamentState) => void;
+  currentTournament: number | null;
+  setCurrentTournament: (id: number | null) => void;
+  joinTournament: (tournamentId: number) => void;
+  leaveTournament: () => void;
+  goToLobby: () => void;
+  goToWaitingRoom: () => void;
+  goToBracket: () => void;
+  goToResult: () => void;
+}
+
+const TournamentContext = createContext<TournamentContextType | undefined>(
+  undefined,
+);
+
+interface TournamentProviderProps {
+  children: ReactNode;
+}
+
+export function TournamentProvider({ children }: TournamentProviderProps) {
+  const [tournamentState, setTournamentState] =
+    useState<TournamentState>("lobby");
+  const [currentTournament, setCurrentTournament] = useState<number | null>(
+    null,
+  );
+
+  const joinTournament = (tournamentId: number) => {
+    setCurrentTournament(tournamentId);
+    setTournamentState("waiting");
+  };
+
+  const leaveTournament = () => {
+    setCurrentTournament(null);
+    setTournamentState("lobby");
+  };
+
+  const goToLobby = () => setTournamentState("lobby");
+  const goToWaitingRoom = () => setTournamentState("waiting");
+  const goToBracket = () => setTournamentState("bracket");
+  const goToResult = () => setTournamentState("result");
+
+  const value: TournamentContextType = {
+    tournamentState,
+    setTournamentState,
+    currentTournament,
+    setCurrentTournament,
+    joinTournament,
+    leaveTournament,
+    goToLobby,
+    goToWaitingRoom,
+    goToBracket,
+    goToResult,
+  };
+
+  return (
+    <TournamentContext.Provider value={value}>
+      {children}
+    </TournamentContext.Provider>
+  );
+}
+
+export function useTournament() {
+  const context = useContext(TournamentContext);
+  if (context === undefined) {
+    throw new Error("useTournament must be used within a TournamentProvider");
+  }
+  return context;
+}

--- a/frontend/src/app/(authed)/tournament/context/index.ts
+++ b/frontend/src/app/(authed)/tournament/context/index.ts
@@ -1,0 +1,2 @@
+export { TournamentProvider, useTournament } from "./TournamentContext";
+export type { TournamentState } from "./TournamentContext";

--- a/frontend/src/app/(authed)/tournament/page.tsx
+++ b/frontend/src/app/(authed)/tournament/page.tsx
@@ -1,22 +1,22 @@
 "use client";
 
-import { useState } from "react";
-
 import { TournamentBracket } from "./components/TournamentBracket";
 import { TournamentLobby } from "./components/TournamentLobby";
 import { TournamentResult } from "./components/TournamentResult";
 import { TournamentWaitingRoom } from "./components/TournamentWaitingRoom";
+import { TournamentProvider, useTournament } from "./context/TournamentContext";
 import styles from "./tournament.module.css";
 
-// ダミーのトーナメント状態
-type TournamentState = "lobby" | "waiting" | "bracket" | "result";
-
 export default function TournamentPage() {
-  const [tournamentState, setTournamentState] =
-    useState<TournamentState>("lobby");
-  const [currentTournament, setCurrentTournament] = useState<number | null>(
-    null,
+  return (
+    <TournamentProvider>
+      <TournamentContent />
+    </TournamentProvider>
   );
+}
+
+function TournamentContent() {
+  const { tournamentState, setTournamentState } = useTournament();
 
   // ダミーの試合結果
   const dummyWinner = {
@@ -42,9 +42,9 @@ export default function TournamentPage() {
 
   return (
     <div className="container mx-auto min-h-screen pt-18 pb-13">
+
       <div className={styles.tournamentContainer}>
-        
-        {/* 仮の切り替えコンポーネント */}
+        {/* 仮の切り替えコンポーネント - デバッグ用 */}
         <div className="mb-4 flex space-x-3">
           <button
             type="button"
@@ -75,6 +75,7 @@ export default function TournamentPage() {
             Results
           </button>
         </div>
+
         {renderContent()}
       </div>
     </div>

--- a/frontend/src/app/(authed)/tournament/page.tsx
+++ b/frontend/src/app/(authed)/tournament/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+
+import { TournamentBracket } from "./components/TournamentBracket";
+import { TournamentLobby } from "./components/TournamentLobby";
+import { TournamentResult } from "./components/TournamentResult";
+import { TournamentWaitingRoom } from "./components/TournamentWaitingRoom";
+import styles from "./tournament.module.css";
+
+// ダミーのトーナメント状態
+type TournamentState = "lobby" | "waiting" | "bracket" | "result";
+
+export default function TournamentPage() {
+  const [tournamentState, setTournamentState] =
+    useState<TournamentState>("lobby");
+  const [currentTournament, setCurrentTournament] = useState<number | null>(
+    null,
+  );
+
+  // ダミーの試合結果
+  const dummyWinner = {
+    id: 1,
+    name: "Player1",
+    score: 5,
+  };
+
+  const renderContent = () => {
+    switch (tournamentState) {
+      case "lobby":
+        return <TournamentLobby />;
+      case "waiting":
+        return <TournamentWaitingRoom />;
+      case "bracket":
+        return <TournamentBracket />;
+      case "result":
+        return <TournamentResult winner={dummyWinner} isFinal={true} />;
+      default:
+        return <TournamentLobby />;
+    }
+  };
+
+  return (
+    <div className="container mx-auto min-h-screen pt-18 pb-13">
+      <div className={styles.tournamentContainer}>
+        
+        {/* 仮の切り替えコンポーネント */}
+        <div className="mb-4 flex space-x-3">
+          <button
+            type="button"
+            className={`rounded px-4 py-2 ${tournamentState === "lobby" ? "bg-blue-600 text-white" : "bg-gray-200"}`}
+            onClick={() => setTournamentState("lobby")}
+          >
+            Lobby
+          </button>
+          <button
+            type="button"
+            className={`rounded px-4 py-2 ${tournamentState === "waiting" ? "bg-blue-600 text-white" : "bg-gray-200"}`}
+            onClick={() => setTournamentState("waiting")}
+          >
+            Waiting Room
+          </button>
+          <button
+            type="button"
+            className={`rounded px-4 py-2 ${tournamentState === "bracket" ? "bg-blue-600 text-white" : "bg-gray-200"}`}
+            onClick={() => setTournamentState("bracket")}
+          >
+            Tournament Bracket
+          </button>
+          <button
+            type="button"
+            className={`rounded px-4 py-2 ${tournamentState === "result" ? "bg-blue-600 text-white" : "bg-gray-200"}`}
+            onClick={() => setTournamentState("result")}
+          >
+            Results
+          </button>
+        </div>
+        {renderContent()}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(authed)/tournament/tournament.module.css
+++ b/frontend/src/app/(authed)/tournament/tournament.module.css
@@ -1,0 +1,9 @@
+.tournamentContainer {
+  width: 100%;
+  margin-top: 20px;
+  background-color: rgba(0, 20, 40, 0.7);
+  border: 1px solid var(--cyber-primary);
+  border-radius: 8px;
+  box-shadow: 0 0 20px rgba(0, 255, 255, 0.3);
+  padding: 30px;
+}


### PR DESCRIPTION
- 実際のバックエンドロジックは一切使用していない。

<img width="1320" alt="スクリーンショット 2025-05-24 21 08 59" src="https://github.com/user-attachments/assets/7034a02a-9904-425c-9a61-0f19dccb6ef8" />

こんな感じでトーナメントボタンを追加し、

<img width="1276" alt="スクリーンショット 2025-05-24 21 12 43" src="https://github.com/user-attachments/assets/670544e2-5d3d-47e6-8824-18734e867491" />

のような形でトーナメントロジックのフローを実行する想定。
[Lobby], [Wating Room]...などのボタンは今後消去して、状態管理で遷移できるようにする。

