### PR TITLE
update(backend): トーナメントで使用するエンドポイントを作成した。

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,9 +1,13 @@
 import type { FastifyInstance } from "fastify";
 import usersRoutes from "./user/user";
+import tournamentRoutes from "./tournament/tournament";
+import tournamentSocketRoute from "./tournament/socket";
 
 import gameIdRoute from "./game/socket";
 
 export default async function routes(fastify: FastifyInstance) {
   fastify.register(usersRoutes, { prefix: "/user" });
+  fastify.register(tournamentRoutes, { prefix: "/tournament" });
+  fastify.register(tournamentSocketRoute, { prefix: "/tournament" });
   fastify.register(gameIdRoute, { prefix: "/game" });
 }

--- a/backend/src/routes/tournament/socket.ts
+++ b/backend/src/routes/tournament/socket.ts
@@ -1,0 +1,169 @@
+import type { FastifyInstance } from "fastify";
+import type { WebSocket } from "@fastify/websocket";
+import { TournamentService } from "../../services/tournament/TournamentService";
+
+// トーナメント待機室の接続を管理
+const tournamentConnections = new Map<string, Set<WebSocket>>();
+
+export default async function tournamentSocketRoute(fastify: FastifyInstance) {
+  const tournamentService = new TournamentService();
+
+  // トーナメント待機室のWebSocket接続
+  fastify.get<{ Params: { tournamentId: string } }>(
+    "/:tournamentId/ws",
+    { websocket: true },
+    (connection, req) => {
+      const { tournamentId } = req.params;
+
+      // 接続をトーナメントルームに追加
+      if (!tournamentConnections.has(tournamentId)) {
+        tournamentConnections.set(tournamentId, new Set());
+      }
+      tournamentConnections.get(tournamentId)!.add(connection);
+
+      console.log(`トーナメント ${tournamentId} に接続しました`);
+
+      // 接続時に現在の状態を送信
+      sendTournamentUpdate(tournamentId, tournamentService);
+
+      // メッセージハンドラー
+      connection.on("message", async (message: Buffer) => {
+        try {
+          const data = JSON.parse(message.toString());
+          
+          switch (data.type) {
+            case "join":
+              await handleJoinTournament(data, tournamentId, tournamentService);
+              break;
+            case "start":
+              await handleStartTournament(data, tournamentId, tournamentService);
+              break;
+            case "chat":
+              handleTournamentChat(data, tournamentId);
+              break;
+            default:
+              console.log(`Unknown message type: ${data.type}`);
+          }
+        } catch (error) {
+          console.error("トーナメントWebSocketメッセージ処理エラー:", error);
+        }
+      });
+
+      // 接続終了時のクリーンアップ
+      connection.on("close", () => {
+        const connections = tournamentConnections.get(tournamentId);
+        if (connections) {
+          connections.delete(connection);
+          if (connections.size === 0) {
+            tournamentConnections.delete(tournamentId);
+          }
+        }
+        console.log(`トーナメント ${tournamentId} から切断しました`);
+      });
+    }
+  );
+}
+
+/**
+ * トーナメント参加処理
+ */
+async function handleJoinTournament(
+  data: any,
+  tournamentId: string,
+  tournamentService: TournamentService
+) {
+  try {
+    const { userId } = data;
+    await tournamentService.joinTournament(tournamentId, userId);
+    
+    // 全員に更新を通知
+    await sendTournamentUpdate(tournamentId, tournamentService);
+  } catch (error) {
+    console.error("トーナメント参加エラー:", error);
+    // エラーを特定の接続に送信する実装は後で追加
+  }
+}
+
+/**
+ * トーナメント開始処理
+ */
+async function handleStartTournament(
+  data: any,
+  tournamentId: string,
+  tournamentService: TournamentService
+) {
+  try {
+    const { creatorId } = data;
+    await tournamentService.startTournament(tournamentId, creatorId);
+    
+    // 全員に更新を通知
+    await sendTournamentUpdate(tournamentId, tournamentService);
+  } catch (error) {
+    console.error("トーナメント開始エラー:", error);
+  }
+}
+
+/**
+ * トーナメントチャット処理
+ */
+function handleTournamentChat(data: any, tournamentId: string) {
+  const { name, message } = data;
+  
+  const chatMessage = JSON.stringify({
+    type: "chat",
+    name,
+    message,
+    timestamp: Date.now(),
+  });
+
+  // トーナメント内の全員にチャットを送信
+  broadcastToTournament(tournamentId, chatMessage);
+}
+
+/**
+ * トーナメント状態更新を全員に送信
+ */
+async function sendTournamentUpdate(
+  tournamentId: string,
+  tournamentService: TournamentService
+) {
+  try {
+    const tournament = await tournamentService.getTournamentWithDetails(tournamentId);
+    if (!tournament) return;
+
+    const updateMessage = JSON.stringify({
+      type: "tournamentUpdate",
+      tournament,
+    });
+
+    broadcastToTournament(tournamentId, updateMessage);
+  } catch (error) {
+    console.error("トーナメント状態更新送信エラー:", error);
+  }
+}
+
+/**
+ * トーナメント内の全員にメッセージをブロードキャスト
+ */
+function broadcastToTournament(tournamentId: string, message: string) {
+  const connections = tournamentConnections.get(tournamentId);
+  if (!connections) return;
+
+  connections.forEach((connection) => {
+    try {
+      if (connection.readyState === connection.OPEN) {
+        connection.send(message);
+      }
+    } catch (error) {
+      console.error("メッセージ送信エラー:", error);
+    }
+  });
+}
+
+/**
+ * 外部からトーナメント更新を送信するための関数をエクスポート
+ */
+export function notifyTournamentUpdate(tournamentId: string) {
+  const tournamentService = new TournamentService();
+  sendTournamentUpdate(tournamentId, tournamentService);
+}

--- a/backend/src/routes/tournament/socket.ts
+++ b/backend/src/routes/tournament/socket.ts
@@ -30,13 +30,17 @@ export default async function tournamentSocketRoute(fastify: FastifyInstance) {
       connection.on("message", async (message: Buffer) => {
         try {
           const data = JSON.parse(message.toString());
-          
+
           switch (data.type) {
             case "join":
               await handleJoinTournament(data, tournamentId, tournamentService);
               break;
             case "start":
-              await handleStartTournament(data, tournamentId, tournamentService);
+              await handleStartTournament(
+                data,
+                tournamentId,
+                tournamentService,
+              );
               break;
             case "chat":
               handleTournamentChat(data, tournamentId);
@@ -60,7 +64,7 @@ export default async function tournamentSocketRoute(fastify: FastifyInstance) {
         }
         console.log(`トーナメント ${tournamentId} から切断しました`);
       });
-    }
+    },
   );
 }
 
@@ -70,12 +74,12 @@ export default async function tournamentSocketRoute(fastify: FastifyInstance) {
 async function handleJoinTournament(
   data: any,
   tournamentId: string,
-  tournamentService: TournamentService
+  tournamentService: TournamentService,
 ) {
   try {
     const { userId } = data;
     await tournamentService.joinTournament(tournamentId, userId);
-    
+
     // 全員に更新を通知
     await sendTournamentUpdate(tournamentId, tournamentService);
   } catch (error) {
@@ -90,12 +94,12 @@ async function handleJoinTournament(
 async function handleStartTournament(
   data: any,
   tournamentId: string,
-  tournamentService: TournamentService
+  tournamentService: TournamentService,
 ) {
   try {
     const { creatorId } = data;
     await tournamentService.startTournament(tournamentId, creatorId);
-    
+
     // 全員に更新を通知
     await sendTournamentUpdate(tournamentId, tournamentService);
   } catch (error) {
@@ -108,7 +112,7 @@ async function handleStartTournament(
  */
 function handleTournamentChat(data: any, tournamentId: string) {
   const { name, message } = data;
-  
+
   const chatMessage = JSON.stringify({
     type: "chat",
     name,
@@ -125,10 +129,11 @@ function handleTournamentChat(data: any, tournamentId: string) {
  */
 async function sendTournamentUpdate(
   tournamentId: string,
-  tournamentService: TournamentService
+  tournamentService: TournamentService,
 ) {
   try {
-    const tournament = await tournamentService.getTournamentWithDetails(tournamentId);
+    const tournament =
+      await tournamentService.getTournamentWithDetails(tournamentId);
     if (!tournament) return;
 
     const updateMessage = JSON.stringify({

--- a/backend/src/routes/tournament/tournament.ts
+++ b/backend/src/routes/tournament/tournament.ts
@@ -1,0 +1,170 @@
+import type { FastifyInstance } from "fastify";
+import { TournamentService } from "../../services/tournament/TournamentService";
+import type {
+  CreateTournamentRequest,
+  JoinTournamentRequest,
+  StartTournamentRequest,
+} from "@ft-transcendence/shared";
+
+export default async function tournamentRoutes(fastify: FastifyInstance) {
+  const tournamentService = new TournamentService();
+
+  // 利用可能なトーナメント一覧を取得
+  fastify.get("/", async (request, reply) => {
+    try {
+      const tournaments = await tournamentService.getAvailableTournaments();
+      return { tournaments };
+    } catch (error) {
+      fastify.log.error(`トーナメント一覧取得エラー: ${error}`);
+      return reply.status(500).send({ 
+        error: "トーナメント一覧の取得中にエラーが発生しました" 
+      });
+    }
+  });
+
+  // 新しいトーナメントを作成
+  fastify.post<{ Body: CreateTournamentRequest & { creatorId: string } }>(
+    "/",
+    async (request, reply) => {
+      try {
+        const { name, maxParticipants, creatorId } = request.body;
+
+        if (!name || !maxParticipants || !creatorId) {
+          return reply.status(400).send({
+            error: "必須パラメータが不足しています"
+          });
+        }
+
+        if (maxParticipants < 2 || maxParticipants > 32) {
+          return reply.status(400).send({
+            error: "参加者数は2人以上32人以下で設定してください"
+          });
+        }
+
+        const tournament = await tournamentService.createTournament(
+          { name, maxParticipants },
+          creatorId
+        );
+
+        return { tournament };
+      } catch (error) {
+        fastify.log.error(`トーナメント作成エラー: ${error}`);
+        return reply.status(500).send({
+          error: "トーナメントの作成中にエラーが発生しました"
+        });
+      }
+    }
+  );
+
+  // 特定のトーナメントの詳細を取得
+  fastify.get<{ Params: { id: string } }>(
+    "/:id",
+    async (request, reply) => {
+      try {
+        const { id } = request.params;
+        const tournament = await tournamentService.getTournamentWithDetails(id);
+
+        if (!tournament) {
+          return reply.status(404).send({
+            error: "トーナメントが見つかりません"
+          });
+        }
+
+        return { tournament };
+      } catch (error) {
+        fastify.log.error(`トーナメント詳細取得エラー: ${error}`);
+        return reply.status(500).send({
+          error: "トーナメント詳細の取得中にエラーが発生しました"
+        });
+      }
+    }
+  );
+
+  // トーナメントに参加
+  fastify.post<{ 
+    Params: { id: string }; 
+    Body: { userId: string } 
+  }>(
+    "/:id/join",
+    async (request, reply) => {
+      try {
+        const { id } = request.params;
+        const { userId } = request.body;
+
+        if (!userId) {
+          return reply.status(400).send({
+            error: "ユーザーIDが必要です"
+          });
+        }
+
+        await tournamentService.joinTournament(id, userId);
+        return { success: true, message: "トーナメントに参加しました" };
+      } catch (error) {
+        fastify.log.error(`トーナメント参加エラー: ${error}`);
+        
+        // エラーメッセージをそのまま返す（TournamentServiceで適切なエラーメッセージを設定している）
+        return reply.status(400).send({
+          error: error instanceof Error ? error.message : "トーナメント参加中にエラーが発生しました"
+        });
+      }
+    }
+  );
+
+  // トーナメントを開始
+  fastify.post<{ 
+    Params: { id: string }; 
+    Body: { creatorId: string } 
+  }>(
+    "/:id/start",
+    async (request, reply) => {
+      try {
+        const { id } = request.params;
+        const { creatorId } = request.body;
+
+        if (!creatorId) {
+          return reply.status(400).send({
+            error: "作成者IDが必要です"
+          });
+        }
+
+        await tournamentService.startTournament(id, creatorId);
+        return { success: true, message: "トーナメントを開始しました" };
+      } catch (error) {
+        fastify.log.error(`トーナメント開始エラー: ${error}`);
+        
+        return reply.status(400).send({
+          error: error instanceof Error ? error.message : "トーナメント開始中にエラーが発生しました"
+        });
+      }
+    }
+  );
+
+  // 試合結果を報告
+  fastify.post<{ 
+    Params: { matchId: string }; 
+    Body: { winnerId: string; gameId: string } 
+  }>(
+    "/matches/:matchId/result",
+    async (request, reply) => {
+      try {
+        const { matchId } = request.params;
+        const { winnerId, gameId } = request.body;
+
+        if (!winnerId || !gameId) {
+          return reply.status(400).send({
+            error: "勝者IDとゲームIDが必要です"
+          });
+        }
+
+        await tournamentService.processMatchResult(matchId, winnerId, gameId);
+        return { success: true, message: "試合結果を処理しました" };
+      } catch (error) {
+        fastify.log.error(`試合結果処理エラー: ${error}`);
+        
+        return reply.status(400).send({
+          error: error instanceof Error ? error.message : "試合結果処理中にエラーが発生しました"
+        });
+      }
+    }
+  );
+}

--- a/backend/src/routes/tournament/tournament.ts
+++ b/backend/src/routes/tournament/tournament.ts
@@ -16,8 +16,8 @@ export default async function tournamentRoutes(fastify: FastifyInstance) {
       return { tournaments };
     } catch (error) {
       fastify.log.error(`トーナメント一覧取得エラー: ${error}`);
-      return reply.status(500).send({ 
-        error: "トーナメント一覧の取得中にエラーが発生しました" 
+      return reply.status(500).send({
+        error: "トーナメント一覧の取得中にエラーが発生しました",
       });
     }
   });
@@ -31,140 +31,137 @@ export default async function tournamentRoutes(fastify: FastifyInstance) {
 
         if (!name || !maxParticipants || !creatorId) {
           return reply.status(400).send({
-            error: "必須パラメータが不足しています"
+            error: "必須パラメータが不足しています",
           });
         }
 
         if (maxParticipants < 2 || maxParticipants > 32) {
           return reply.status(400).send({
-            error: "参加者数は2人以上32人以下で設定してください"
+            error: "参加者数は2人以上32人以下で設定してください",
           });
         }
 
         const tournament = await tournamentService.createTournament(
           { name, maxParticipants },
-          creatorId
+          creatorId,
         );
 
         return { tournament };
       } catch (error) {
         fastify.log.error(`トーナメント作成エラー: ${error}`);
         return reply.status(500).send({
-          error: "トーナメントの作成中にエラーが発生しました"
+          error: "トーナメントの作成中にエラーが発生しました",
         });
       }
-    }
+    },
   );
 
   // 特定のトーナメントの詳細を取得
-  fastify.get<{ Params: { id: string } }>(
-    "/:id",
-    async (request, reply) => {
-      try {
-        const { id } = request.params;
-        const tournament = await tournamentService.getTournamentWithDetails(id);
+  fastify.get<{ Params: { id: string } }>("/:id", async (request, reply) => {
+    try {
+      const { id } = request.params;
+      const tournament = await tournamentService.getTournamentWithDetails(id);
 
-        if (!tournament) {
-          return reply.status(404).send({
-            error: "トーナメントが見つかりません"
-          });
-        }
-
-        return { tournament };
-      } catch (error) {
-        fastify.log.error(`トーナメント詳細取得エラー: ${error}`);
-        return reply.status(500).send({
-          error: "トーナメント詳細の取得中にエラーが発生しました"
+      if (!tournament) {
+        return reply.status(404).send({
+          error: "トーナメントが見つかりません",
         });
       }
+
+      return { tournament };
+    } catch (error) {
+      fastify.log.error(`トーナメント詳細取得エラー: ${error}`);
+      return reply.status(500).send({
+        error: "トーナメント詳細の取得中にエラーが発生しました",
+      });
     }
-  );
+  });
 
   // トーナメントに参加
-  fastify.post<{ 
-    Params: { id: string }; 
-    Body: { userId: string } 
-  }>(
-    "/:id/join",
-    async (request, reply) => {
-      try {
-        const { id } = request.params;
-        const { userId } = request.body;
+  fastify.post<{
+    Params: { id: string };
+    Body: { userId: string };
+  }>("/:id/join", async (request, reply) => {
+    try {
+      const { id } = request.params;
+      const { userId } = request.body;
 
-        if (!userId) {
-          return reply.status(400).send({
-            error: "ユーザーIDが必要です"
-          });
-        }
-
-        await tournamentService.joinTournament(id, userId);
-        return { success: true, message: "トーナメントに参加しました" };
-      } catch (error) {
-        fastify.log.error(`トーナメント参加エラー: ${error}`);
-        
-        // エラーメッセージをそのまま返す（TournamentServiceで適切なエラーメッセージを設定している）
+      if (!userId) {
         return reply.status(400).send({
-          error: error instanceof Error ? error.message : "トーナメント参加中にエラーが発生しました"
+          error: "ユーザーIDが必要です",
         });
       }
+
+      await tournamentService.joinTournament(id, userId);
+      return { success: true, message: "トーナメントに参加しました" };
+    } catch (error) {
+      fastify.log.error(`トーナメント参加エラー: ${error}`);
+
+      // エラーメッセージをそのまま返す（TournamentServiceで適切なエラーメッセージを設定している）
+      return reply.status(400).send({
+        error:
+          error instanceof Error
+            ? error.message
+            : "トーナメント参加中にエラーが発生しました",
+      });
     }
-  );
+  });
 
   // トーナメントを開始
-  fastify.post<{ 
-    Params: { id: string }; 
-    Body: { creatorId: string } 
-  }>(
-    "/:id/start",
-    async (request, reply) => {
-      try {
-        const { id } = request.params;
-        const { creatorId } = request.body;
+  fastify.post<{
+    Params: { id: string };
+    Body: { creatorId: string };
+  }>("/:id/start", async (request, reply) => {
+    try {
+      const { id } = request.params;
+      const { creatorId } = request.body;
 
-        if (!creatorId) {
-          return reply.status(400).send({
-            error: "作成者IDが必要です"
-          });
-        }
-
-        await tournamentService.startTournament(id, creatorId);
-        return { success: true, message: "トーナメントを開始しました" };
-      } catch (error) {
-        fastify.log.error(`トーナメント開始エラー: ${error}`);
-        
+      if (!creatorId) {
         return reply.status(400).send({
-          error: error instanceof Error ? error.message : "トーナメント開始中にエラーが発生しました"
+          error: "作成者IDが必要です",
         });
       }
+
+      await tournamentService.startTournament(id, creatorId);
+      return { success: true, message: "トーナメントを開始しました" };
+    } catch (error) {
+      fastify.log.error(`トーナメント開始エラー: ${error}`);
+
+      return reply.status(400).send({
+        error:
+          error instanceof Error
+            ? error.message
+            : "トーナメント開始中にエラーが発生しました",
+      });
     }
-  );
+  });
 
   // 試合結果を報告
-  fastify.post<{ 
-    Params: { matchId: string }; 
-    Body: { winnerId: string; gameId: string } 
-  }>(
-    "/matches/:matchId/result",
-    async (request, reply) => {
-      try {
-        const { matchId } = request.params;
-        const { winnerId, gameId } = request.body;
+  fastify.post<{
+    Params: { matchId: string };
+    Body: { winnerId: string; gameId: string };
+  }>("/matches/:matchId/result", async (request, reply) => {
+    try {
+      const { matchId } = request.params;
+      const { winnerId, gameId } = request.body;
 
-        if (!winnerId || !gameId) {
-          return reply.status(400).send({
-            error: "勝者IDとゲームIDが必要です"
-          });
-        }
-
-        await tournamentService.processMatchResult(matchId, winnerId, gameId);
-        return { success: true, message: "試合結果を処理しました" };
-      } catch (error) {
-        fastify.log.error(`試合結果処理エラー: ${error}`);
-        
+      if (!winnerId || !gameId) {
         return reply.status(400).send({
-          error: error instanceof Error ? error.message : "試合結果処理中にエラーが発生しました"
+          error: "勝者IDとゲームIDが必要です",
         });
       }
+
+      await tournamentService.processMatchResult(matchId, winnerId, gameId);
+      return { success: true, message: "試合結果を処理しました" };
+    } catch (error) {
+      fastify.log.error(`試合結果処理エラー: ${error}`);
+
+      return reply.status(400).send({
+        error:
+          error instanceof Error
+            ? error.message
+            : "試合結果処理中にエラーが発生しました",
+      });
     }
-  );
+  });
 }

--- a/backend/src/services/tournament/TournamentService.ts
+++ b/backend/src/services/tournament/TournamentService.ts
@@ -1,0 +1,567 @@
+import { db } from "../../db";
+import {
+  tournaments,
+  tournamentParticipants,
+  tournamentMatches,
+  user,
+} from "@ft-transcendence/shared";
+import { eq, and, desc, inArray } from "drizzle-orm";
+import { createTournamentGameRoom } from "../game/roomUtils";
+import { gameRooms } from "../game/index";
+import type {
+  Tournament,
+  TournamentWithDetails,
+  CreateTournamentRequest,
+  TournamentParticipant,
+  TournamentMatch,
+} from "@ft-transcendence/shared";
+
+export class TournamentService {
+  /**
+   * 利用可能なトーナメントと参加中のトーナメントを取得
+   */
+  async getTournamentsForUser(userId: string): Promise<{
+    availableTournaments: TournamentWithDetails[];
+    participatingTournaments: TournamentWithDetails[];
+  }> {
+    // 利用可能なトーナメント（waiting状態）
+    const availableTournaments = await this.getAvailableTournaments();
+
+    // 参加中のトーナメント（in_progress状態で自分が参加しているもの）
+    const participatingQuery = await db
+      .select()
+      .from(tournaments)
+      .innerJoin(
+        tournamentParticipants,
+        eq(tournaments.id, tournamentParticipants.tournamentId)
+      )
+      .where(
+        and(
+          eq(tournaments.status, "in_progress"),
+          eq(tournamentParticipants.userId, userId),
+          eq(tournamentParticipants.status, "active")
+        )
+      );
+
+    const participatingTournaments = await Promise.all(
+      participatingQuery.map(async ({ tournaments: tournament }) => {
+        const details = await this.getTournamentWithDetails(tournament.id);
+        return details!;
+      })
+    );
+
+    return {
+      availableTournaments,
+      participatingTournaments,
+    };
+  }
+  /**
+   * 新しいトーナメントを作成
+   */
+  async createTournament(
+    request: CreateTournamentRequest,
+    creatorId: string
+  ): Promise<Tournament> {
+    const tournamentId = crypto.randomUUID();
+    const now = Date.now();
+
+    // トーナメントを作成
+    await db.insert(tournaments).values({
+      id: tournamentId,
+      name: request.name,
+      creatorId: creatorId,
+      maxParticipants: request.maxParticipants,
+      status: "waiting",
+      currentRound: 0,
+      createdAt: now,
+    });
+
+    // 作成者を自動的に参加者として追加
+    await db.insert(tournamentParticipants).values({
+      id: crypto.randomUUID(),
+      tournamentId: tournamentId,
+      userId: creatorId,
+      status: "active",
+      joinedAt: now,
+    });
+
+    return {
+      id: tournamentId,
+      name: request.name,
+      creatorId: creatorId,
+      status: "waiting",
+      maxParticipants: request.maxParticipants,
+      currentRound: 0,
+      createdAt: now,
+    };
+  }
+
+  /**
+   * トーナメントに参加
+   */
+  async joinTournament(tournamentId: string, userId: string): Promise<boolean> {
+    // トーナメントの存在確認
+    const tournament = await this.getTournamentById(tournamentId);
+    if (!tournament) {
+      throw new Error("トーナメントが見つかりません");
+    }
+
+    if (tournament.status !== "waiting") {
+      throw new Error("このトーナメントは参加受付を終了しています");
+    }
+
+    // 既に参加しているかチェック
+    const existingParticipant = await db
+      .select()
+      .from(tournamentParticipants)
+      .where(
+        and(
+          eq(tournamentParticipants.tournamentId, tournamentId),
+          eq(tournamentParticipants.userId, userId)
+        )
+      )
+      .limit(1);
+
+    if (existingParticipant.length > 0) {
+      throw new Error("既にこのトーナメントに参加しています");
+    }
+
+    // 現在の参加者数をチェック
+    const participantCount = await db
+      .select()
+      .from(tournamentParticipants)
+      .where(eq(tournamentParticipants.tournamentId, tournamentId));
+
+    if (participantCount.length >= tournament.maxParticipants) {
+      throw new Error("トーナメントの参加者数が上限に達しています");
+    }
+
+    // 参加者として追加
+    await db.insert(tournamentParticipants).values({
+      id: crypto.randomUUID(),
+      tournamentId: tournamentId,
+      userId: userId,
+      status: "active",
+      joinedAt: Date.now(),
+    });
+
+    return true;
+  }
+
+  /**
+   * トーナメントを開始（ブラケット生成）
+   */
+  async startTournament(
+    tournamentId: string,
+    creatorId: string
+  ): Promise<void> {
+    const tournament = await this.getTournamentById(tournamentId);
+    if (!tournament) {
+      throw new Error("トーナメントが見つかりません");
+    }
+
+    if (tournament.creatorId !== creatorId) {
+      throw new Error("トーナメントを開始する権限がありません");
+    }
+
+    if (tournament.status !== "waiting") {
+      throw new Error("このトーナメントは既に開始されています");
+    }
+
+    // 参加者を取得
+    const participants = await db
+      .select()
+      .from(tournamentParticipants)
+      .where(eq(tournamentParticipants.tournamentId, tournamentId));
+
+    if (participants.length < 2) {
+      throw new Error("トーナメントを開始するには最低2人の参加者が必要です");
+    }
+
+    // トーナメント状態を更新
+    await db
+      .update(tournaments)
+      .set({
+        status: "in_progress",
+        startedAt: Date.now(),
+        currentRound: 1,
+      })
+      .where(eq(tournaments.id, tournamentId));
+
+    // 第1ラウンドの試合を生成
+    await this.generateRoundMatches(tournamentId, participants, 1);
+  }
+
+  /**
+   * ラウンドの試合を生成
+   */
+  private async generateRoundMatches(
+    tournamentId: string,
+    participants: any[],
+    round: number
+  ): Promise<void> {
+    // 参加者をシャッフル
+    const shuffledParticipants = [...participants].sort(
+      () => Math.random() - 0.5
+    );
+
+    const matches: any[] = [];
+    let matchNumber = 1;
+
+    // ペアを作成
+    for (let i = 0; i < shuffledParticipants.length; i += 2) {
+      if (i + 1 < shuffledParticipants.length) {
+        const matchId = crypto.randomUUID();
+        matches.push({
+          id: matchId,
+          tournamentId: tournamentId,
+          round: round,
+          matchNumber: matchNumber++,
+          player1Id: shuffledParticipants[i].userId,
+          player2Id: shuffledParticipants[i + 1].userId,
+          status: "pending",
+          scheduledAt: Date.now(),
+        });
+      }
+    }
+
+    // 試合をデータベースに保存
+    if (matches.length > 0) {
+      await db.insert(tournamentMatches).values(matches);
+
+      // 各試合用のゲームルームを作成
+      for (const match of matches) {
+        this.createMatchGameRoom(tournamentId, match.id);
+      }
+    }
+  }
+
+  /**
+   * 試合用のゲームルームを作成
+   */
+  private createMatchGameRoom(tournamentId: string, matchId: string): string {
+    const { roomId } = createTournamentGameRoom(
+      tournamentId,
+      matchId,
+      gameRooms
+    );
+    console.log(`トーナメント試合用ルーム作成: ${roomId} (試合ID: ${matchId})`);
+    return roomId;
+  }
+
+  /**
+   * トーナメント詳細を取得
+   */
+  async getTournamentWithDetails(
+    tournamentId: string
+  ): Promise<TournamentWithDetails | null> {
+    const tournament = await this.getTournamentById(tournamentId);
+    if (!tournament) {
+      return null;
+    }
+
+    // 参加者情報を取得（ユーザー名付き）
+    const participantsWithUsersFromDB = await db
+      .select({
+        id: tournamentParticipants.id,
+        tournamentId: tournamentParticipants.tournamentId,
+        userId: tournamentParticipants.userId,
+        status: tournamentParticipants.status,
+        eliminatedRound: tournamentParticipants.eliminatedRound,
+        joinedAt: tournamentParticipants.joinedAt,
+        userName: user.name,
+      })
+      .from(tournamentParticipants)
+      .innerJoin(user, eq(tournamentParticipants.userId, user.id))
+      .where(eq(tournamentParticipants.tournamentId, tournamentId));
+
+    // 現在のラウンドの試合を取得
+    let currentMatches: TournamentMatch[] = [];
+    if (tournament.status === "in_progress") {
+      currentMatches = (await db
+        .select()
+        .from(tournamentMatches)
+        .where(
+          and(
+            eq(tournamentMatches.tournamentId, tournamentId),
+            eq(tournamentMatches.round, tournament.currentRound)
+          )
+        )) as unknown as TournamentMatch[];
+    }
+    const participantsWithUsers: Array<
+      TournamentParticipant & { userName: string }
+    > = participantsWithUsersFromDB.map((item) => ({
+      id: item.id,
+      tournamentId: item.tournamentId,
+      userId: item.userId,
+      status: item.status as "active" | "eliminated" | "winner",
+      eliminatedRound: item.eliminatedRound ?? undefined,
+      joinedAt: item.joinedAt,
+      userName: item.userName ?? "Unknown User",
+    }));
+    return {
+      ...tournament,
+      participants: participantsWithUsers,
+      currentMatches,
+    };
+  }
+
+  /**
+   * すべてのトーナメントを取得（waiting状態のもの）
+   */
+  async getAvailableTournaments(): Promise<TournamentWithDetails[]> {
+    const tournamentListFromDB = await db
+      .select()
+      .from(tournaments)
+      .where(eq(tournaments.status, "waiting"))
+      .orderBy(desc(tournaments.createdAt));
+
+    if (tournamentListFromDB.length === 0) {
+      return [];
+    }
+    const tournamentList: Tournament[] = tournamentListFromDB.map(
+      (tournament) => ({
+        id: tournament.id,
+        name: tournament.name,
+        creatorId: tournament.creatorId,
+        status: tournament.status as
+          | "waiting"
+          | "in_progress"
+          | "completed"
+          | "cancelled",
+        maxParticipants: tournament.maxParticipants,
+        currentRound: tournament.currentRound,
+        winnerId: tournament.winnerId ?? undefined,
+        createdAt: tournament.createdAt,
+        startedAt: tournament.startedAt ?? undefined,
+        endedAt: tournament.endedAt ?? undefined,
+      })
+    );
+
+    // 全トーナメントの参加者を一度に取得
+    const allParticipantsFromDB = await db
+      .select({
+        id: tournamentParticipants.id,
+        tournamentId: tournamentParticipants.tournamentId,
+        userId: tournamentParticipants.userId,
+        status: tournamentParticipants.status,
+        eliminatedRound: tournamentParticipants.eliminatedRound,
+        joinedAt: tournamentParticipants.joinedAt,
+        userName: user.name,
+      })
+      .from(tournamentParticipants)
+      .innerJoin(user, eq(tournamentParticipants.userId, user.id))
+      .where(
+        inArray(
+          tournamentParticipants.tournamentId,
+          tournamentList.map((t) => t.id)
+        )
+      );
+
+    // allParticipantsFromDB を適切な型に変換
+    const allParticipants = allParticipantsFromDB.map((item) => ({
+      id: item.id,
+      tournamentId: item.tournamentId,
+      userId: item.userId,
+      status: item.status as "active" | "eliminated" | "winner",
+      eliminatedRound: item.eliminatedRound ?? undefined,
+      joinedAt: item.joinedAt,
+      userName: item.userName ?? "Unknown User",
+    }));
+
+    // トーナメントIDでグループ化
+    const participantsByTournament = allParticipants.reduce(
+      (acc, participant) => {
+        if (!acc[participant.tournamentId]) {
+          acc[participant.tournamentId] = [];
+        }
+        acc[participant.tournamentId].push(participant);
+        return acc;
+      },
+      {} as Record<string, typeof allParticipants>
+    );
+
+    return tournamentList.map((tournament) => ({
+      ...tournament,
+      participants: participantsByTournament[tournament.id] || [],
+      currentMatches: [], // waiting状態なので空配列
+    }));
+  }
+
+  /**
+   * 試合結果を処理し、次のラウンドを進行
+   */
+  async processMatchResult(
+    matchId: string,
+    winnerId: string,
+    gameId: string
+  ): Promise<void> {
+    // 試合情報を取得
+    const match = await db
+      .select()
+      .from(tournamentMatches)
+      .where(eq(tournamentMatches.id, matchId))
+      .limit(1);
+
+    if (match.length === 0) {
+      throw new Error("試合が見つかりません");
+    }
+
+    const currentMatch = match[0];
+
+    // 試合結果を更新
+    await db
+      .update(tournamentMatches)
+      .set({
+        winnerId: winnerId,
+        gameId: gameId,
+        status: "completed",
+      })
+      .where(eq(tournamentMatches.id, matchId));
+
+    // 敗者を脱落状態に更新
+    const loserId =
+      currentMatch.player1Id === winnerId
+        ? currentMatch.player2Id
+        : currentMatch.player1Id;
+
+    await db
+      .update(tournamentParticipants)
+      .set({
+        status: "eliminated",
+        eliminatedRound: currentMatch.round,
+      })
+      .where(
+        and(
+          eq(tournamentParticipants.tournamentId, currentMatch.tournamentId),
+          eq(tournamentParticipants.userId, loserId)
+        )
+      );
+
+    // このラウンドのすべての試合が完了したかチェック
+    await this.checkAndAdvanceRound(
+      currentMatch.tournamentId,
+      currentMatch.round
+    );
+  }
+
+  /**
+   * ラウンド進行をチェックし、必要に応じて次のラウンドを開始
+   */
+  private async checkAndAdvanceRound(
+    tournamentId: string,
+    round: number
+  ): Promise<void> {
+    // このラウンドの試合をすべて取得
+    const roundMatches = await db
+      .select()
+      .from(tournamentMatches)
+      .where(
+        and(
+          eq(tournamentMatches.tournamentId, tournamentId),
+          eq(tournamentMatches.round, round)
+        )
+      );
+
+    const completedMatches = roundMatches.filter(
+      (match) => match.status === "completed"
+    );
+
+    // すべての試合が完了していない場合は何もしない
+    if (completedMatches.length !== roundMatches.length) {
+      return;
+    }
+
+    // 勝者を取得
+    const winners = completedMatches
+      .map((match) => match.winnerId)
+      .filter(Boolean);
+
+    if (winners.length === 1) {
+      // 優勝者決定
+      await db
+        .update(tournaments)
+        .set({
+          status: "completed",
+          winnerId: winners[0],
+          endedAt: Date.now(),
+        })
+        .where(eq(tournaments.id, tournamentId));
+
+      // 優勝者のステータスを更新
+      await db
+        .update(tournamentParticipants)
+        .set({ status: "winner" })
+        .where(
+          and(
+            eq(tournamentParticipants.tournamentId, tournamentId),
+            eq(tournamentParticipants.userId, winners[0] ?? "")
+          )
+        );
+    } else if (winners.length > 1) {
+      // 次のラウンドを開始
+      const nextRound = round + 1;
+
+      await db
+        .update(tournaments)
+        .set({ currentRound: nextRound })
+        .where(eq(tournaments.id, tournamentId));
+
+      // 勝者情報を参加者形式に変換
+      const nextRoundParticipants = winners.map((winnerId) => ({
+        userId: winnerId,
+      }));
+      await this.generateRoundMatches(
+        tournamentId,
+        nextRoundParticipants,
+        nextRound
+      );
+    }
+  }
+
+  /**
+   * 特定の試合のゲームルームIDを取得
+   */
+  async getMatchGameRoomId(matchId: string): Promise<string | null> {
+    // gameRoomsから該当するルームを検索
+    for (const [roomId, room] of gameRooms.entries()) {
+      if (room.tournamentMatchId === matchId) {
+        return roomId;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * IDでトーナメントを取得
+   */
+  private async getTournamentById(
+    tournamentId: string
+  ): Promise<Tournament | null> {
+    const result = await db
+      .select()
+      .from(tournaments)
+      .where(eq(tournaments.id, tournamentId))
+      .limit(1)
+      .then((rows) =>
+        rows.map((row) => ({
+          id: row.id,
+          name: row.name,
+          creatorId: row.creatorId,
+          status: row.status as
+            | "waiting"
+            | "in_progress"
+            | "completed"
+            | "cancelled",
+          maxParticipants: row.maxParticipants,
+          currentRound: row.currentRound,
+          winnerId: row.winnerId ?? undefined,
+          createdAt: row.createdAt,
+          startedAt: row.startedAt ?? undefined,
+          endedAt: row.endedAt ?? undefined,
+        }))
+      );
+
+    return result.length > 0 ? result[0] : null;
+  }
+}

--- a/backend/src/services/tournament/TournamentService.ts
+++ b/backend/src/services/tournament/TournamentService.ts
@@ -33,21 +33,21 @@ export class TournamentService {
       .from(tournaments)
       .innerJoin(
         tournamentParticipants,
-        eq(tournaments.id, tournamentParticipants.tournamentId)
+        eq(tournaments.id, tournamentParticipants.tournamentId),
       )
       .where(
         and(
           eq(tournaments.status, "in_progress"),
           eq(tournamentParticipants.userId, userId),
-          eq(tournamentParticipants.status, "active")
-        )
+          eq(tournamentParticipants.status, "active"),
+        ),
       );
 
     const participatingTournaments = await Promise.all(
       participatingQuery.map(async ({ tournaments: tournament }) => {
         const details = await this.getTournamentWithDetails(tournament.id);
         return details!;
-      })
+      }),
     );
 
     return {
@@ -60,7 +60,7 @@ export class TournamentService {
    */
   async createTournament(
     request: CreateTournamentRequest,
-    creatorId: string
+    creatorId: string,
   ): Promise<Tournament> {
     const tournamentId = crypto.randomUUID();
     const now = Date.now();
@@ -117,8 +117,8 @@ export class TournamentService {
       .where(
         and(
           eq(tournamentParticipants.tournamentId, tournamentId),
-          eq(tournamentParticipants.userId, userId)
-        )
+          eq(tournamentParticipants.userId, userId),
+        ),
       )
       .limit(1);
 
@@ -153,7 +153,7 @@ export class TournamentService {
    */
   async startTournament(
     tournamentId: string,
-    creatorId: string
+    creatorId: string,
   ): Promise<void> {
     const tournament = await this.getTournamentById(tournamentId);
     if (!tournament) {
@@ -198,11 +198,11 @@ export class TournamentService {
   private async generateRoundMatches(
     tournamentId: string,
     participants: any[],
-    round: number
+    round: number,
   ): Promise<void> {
     // 参加者をシャッフル
     const shuffledParticipants = [...participants].sort(
-      () => Math.random() - 0.5
+      () => Math.random() - 0.5,
     );
 
     const matches: any[] = [];
@@ -243,7 +243,7 @@ export class TournamentService {
     const { roomId } = createTournamentGameRoom(
       tournamentId,
       matchId,
-      gameRooms
+      gameRooms,
     );
     console.log(`トーナメント試合用ルーム作成: ${roomId} (試合ID: ${matchId})`);
     return roomId;
@@ -253,7 +253,7 @@ export class TournamentService {
    * トーナメント詳細を取得
    */
   async getTournamentWithDetails(
-    tournamentId: string
+    tournamentId: string,
   ): Promise<TournamentWithDetails | null> {
     const tournament = await this.getTournamentById(tournamentId);
     if (!tournament) {
@@ -284,8 +284,8 @@ export class TournamentService {
         .where(
           and(
             eq(tournamentMatches.tournamentId, tournamentId),
-            eq(tournamentMatches.round, tournament.currentRound)
-          )
+            eq(tournamentMatches.round, tournament.currentRound),
+          ),
         )) as unknown as TournamentMatch[];
     }
     const participantsWithUsers: Array<
@@ -335,7 +335,7 @@ export class TournamentService {
         createdAt: tournament.createdAt,
         startedAt: tournament.startedAt ?? undefined,
         endedAt: tournament.endedAt ?? undefined,
-      })
+      }),
     );
 
     // 全トーナメントの参加者を一度に取得
@@ -354,8 +354,8 @@ export class TournamentService {
       .where(
         inArray(
           tournamentParticipants.tournamentId,
-          tournamentList.map((t) => t.id)
-        )
+          tournamentList.map((t) => t.id),
+        ),
       );
 
     // allParticipantsFromDB を適切な型に変換
@@ -378,7 +378,7 @@ export class TournamentService {
         acc[participant.tournamentId].push(participant);
         return acc;
       },
-      {} as Record<string, typeof allParticipants>
+      {} as Record<string, typeof allParticipants>,
     );
 
     return tournamentList.map((tournament) => ({
@@ -394,7 +394,7 @@ export class TournamentService {
   async processMatchResult(
     matchId: string,
     winnerId: string,
-    gameId: string
+    gameId: string,
   ): Promise<void> {
     // 試合情報を取得
     const match = await db
@@ -434,14 +434,14 @@ export class TournamentService {
       .where(
         and(
           eq(tournamentParticipants.tournamentId, currentMatch.tournamentId),
-          eq(tournamentParticipants.userId, loserId)
-        )
+          eq(tournamentParticipants.userId, loserId),
+        ),
       );
 
     // このラウンドのすべての試合が完了したかチェック
     await this.checkAndAdvanceRound(
       currentMatch.tournamentId,
-      currentMatch.round
+      currentMatch.round,
     );
   }
 
@@ -450,7 +450,7 @@ export class TournamentService {
    */
   private async checkAndAdvanceRound(
     tournamentId: string,
-    round: number
+    round: number,
   ): Promise<void> {
     // このラウンドの試合をすべて取得
     const roundMatches = await db
@@ -459,12 +459,12 @@ export class TournamentService {
       .where(
         and(
           eq(tournamentMatches.tournamentId, tournamentId),
-          eq(tournamentMatches.round, round)
-        )
+          eq(tournamentMatches.round, round),
+        ),
       );
 
     const completedMatches = roundMatches.filter(
-      (match) => match.status === "completed"
+      (match) => match.status === "completed",
     );
 
     // すべての試合が完了していない場合は何もしない
@@ -495,8 +495,8 @@ export class TournamentService {
         .where(
           and(
             eq(tournamentParticipants.tournamentId, tournamentId),
-            eq(tournamentParticipants.userId, winners[0] ?? "")
-          )
+            eq(tournamentParticipants.userId, winners[0] ?? ""),
+          ),
         );
     } else if (winners.length > 1) {
       // 次のラウンドを開始
@@ -514,7 +514,7 @@ export class TournamentService {
       await this.generateRoundMatches(
         tournamentId,
         nextRoundParticipants,
-        nextRound
+        nextRound,
       );
     }
   }
@@ -536,7 +536,7 @@ export class TournamentService {
    * IDでトーナメントを取得
    */
   private async getTournamentById(
-    tournamentId: string
+    tournamentId: string,
   ): Promise<Tournament | null> {
     const result = await db
       .select()
@@ -559,7 +559,7 @@ export class TournamentService {
           createdAt: row.createdAt,
           startedAt: row.startedAt ?? undefined,
           endedAt: row.endedAt ?? undefined,
-        }))
+        })),
       );
 
     return result.length > 0 ? result[0] : null;

--- a/database/schema.ts
+++ b/database/schema.ts
@@ -150,7 +150,9 @@ export const tournaments = sqliteTable("tournaments", {
   creatorId: text("creator_id")
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
-  status: text("status").notNull().default("waiting"), // waiting, in_progress, completed, cancelled
+  status: text("status", { enum: ["waiting", "in_progress", "completed", "cancelled"] })
+    .notNull()
+    .default("waiting"),
   maxParticipants: integer("max_participants").notNull(),
   currentRound: integer("current_round").notNull().default(0),
   winnerId: text("winner_id").references(() => users.id),
@@ -171,7 +173,9 @@ export const tournamentParticipants = sqliteTable(
     userId: text("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
-    status: text("status").notNull().default("active"), // active, eliminated, winner
+    status: text("status", { enum: ["active", "eliminated", "winner"] })
+      .notNull()
+      .default("active"),
     eliminatedRound: integer("eliminated_round"),
     joinedAt: integer("joined_at", { mode: "timestamp_ms" }).notNull().default(sql`CURRENT_TIMESTAMP`),
   },
@@ -199,7 +203,9 @@ export const tournamentMatches = sqliteTable(
       .references(() => users.id, { onDelete: "cascade" }),
     winnerId: text("winner_id").references(() => users.id),
     gameId: text("game_id").references(() => games.id),
-    status: text("status").notNull().default("pending"), // pending, in_progress, completed
+    status: text("status", { enum: ["pending", "in_progress", "completed"] })
+      .notNull()
+      .default("pending"),
     scheduledAt: integer("scheduled_at", { mode: "timestamp_ms" }).notNull().default(sql`CURRENT_TIMESTAMP`),
   },
   (table) => [

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types/types';
 export * from './types/constants';
+export * from './types/tournament';
 export * from './drizzle/schema';
 export * from './drizzle/relations';

--- a/shared/src/types/tournament.ts
+++ b/shared/src/types/tournament.ts
@@ -1,0 +1,61 @@
+// ===========================================
+// トーナメント関連の型定義
+// ===========================================
+
+export interface Tournament {
+  id: string;
+  name: string;
+  creatorId: string;
+  status: "waiting" | "in_progress" | "completed" | "cancelled";
+  maxParticipants: number;
+  currentRound: number;
+  winnerId?: string;
+  createdAt: number;
+  startedAt?: number;
+  endedAt?: number;
+}
+
+export interface TournamentParticipant {
+  id: string;
+  tournamentId: string;
+  userId: string;
+  status: "active" | "eliminated" | "winner";
+  eliminatedRound?: number;
+  joinedAt: number;
+}
+
+export interface TournamentMatch {
+  id: string;
+  tournamentId: string;
+  round: number;
+  matchNumber: number;
+  player1Id: string;
+  player2Id: string;
+  winnerId?: string | null;
+  gameId?: string | null;
+  status: "pending" | "in_progress" | "completed";
+  scheduledAt: number;
+}
+
+export interface TournamentWithDetails extends Tournament {
+  participants: Array<TournamentParticipant & { userName: string }>;
+  currentMatches?: TournamentMatch[];
+}
+
+export interface CreateTournamentRequest {
+  name: string;
+  maxParticipants: number;
+}
+
+export interface JoinTournamentRequest {
+  tournamentId: string;
+}
+
+export interface StartTournamentRequest {
+  tournamentId: string;
+}
+
+export interface TournamentStatus {
+  tournament: TournamentWithDetails;
+  currentUserStatus?: "not_joined" | "joined" | "eliminated" | "active" | "winner";
+}


### PR DESCRIPTION
## 実装した機能

### 1. データベーススキーマ

- `tournaments`: トーナメント情報を管理
- `tournament_participants`: トーナメント参加者を管理
- `tournament_matches`: トーナメント内の試合を管理

### 2. REST API エンドポイント

### トーナメント管理

- `GET /tournament/` - 利用可能なトーナメント一覧を取得
- `POST /tournament/` - 新しいトーナメントを作成
- `GET /tournament/:id` - 特定のトーナメント詳細を取得
- `POST /tournament/:id/join` - トーナメントに参加
- `POST /tournament/:id/start` - トーナメントを開始
- `POST /tournament/matches/:matchId/result` - 試合結果を報告

### WebSocket エンドポイント

- `WS /tournament/:tournamentId/ws` - トーナメント待機室のリアルタイム通信

### 3. サービス層

### TournamentService

- トーナメントの作成・管理
- 参加者の管理
- ブラケット生成（ランダム対戦）
- 試合結果の処理
- 次ラウンドの自動進行
- 優勝者の決定

### ゲームシステム統合

- トーナメント専用ゲームルームの作成
- 試合終了時の自動的なトーナメント進行
- WebSocket経由での状態更新

### 4. 型定義

- `backend/src/types/tournament.d.ts` - トーナメント関連の型定義
- 既存の`GameRoom`型にトーナメント情報を統合

## トーナメントの流れ

1. **トーナメント作成**
    - 部屋作成者がトーナメントを作成
    - 最大参加者数を指定
    - 作成者は自動的に参加者として登録
2. **参加者募集**
    - 他のプレイヤーがトーナメントに参加
    - WebSocketで参加者リストがリアルタイム更新
    - チャット機能で参加者同士の交流
3. **トーナメント開始**
    - 作成者が「開始」ボタンを押す
    - 参加者がランダムにペアリング
    - 各試合用の専用ゲームルームを自動作成
4. **試合進行**
    - プレイヤーは対応するゲームルームに移動
    - 通常のPongゲームをプレイ
    - 試合終了時に結果が自動的にトーナメントシステムに反映
5. **ラウンド進行**
    - すべての試合が終了すると次ラウンドを自動生成
    - 敗者は脱落、勝者は次ラウンドに進出
    - 最終的に1人の優勝者が決定

## WebSocketメッセージ仕様

### クライアント → サーバー

```tsx
// トーナメント参加
{ type: "join", userId: string }

// トーナメント開始
{ type: "start", creatorId: string }

// チャットメッセージ
{ type: "chat", name: string, message: string }

```

### サーバー → クライアント

```tsx
// トーナメント状態更新
{
  type: "tournamentUpdate",
  tournament: TournamentWithDetails
}

// チャットメッセージ
{
  type: "chat",
  name: string,
  message: string,
  timestamp: number
}

```
