### PR TITLE
patch: makeでサービスを全て立てた後、再びmakeでリロードするとsetupがこける問題を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
   elastic-search:
     depends_on:
       setup:
-        condition: service_healthy
+        condition: service_completed_successfully
     image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
     labels:
       co.elastic.logs/module: elasticsearch


### PR DESCRIPTION
変更前は
1. setup サービスはElasticsearchの証明書作成とパスワード設定を行う一回限りのタスク
2. elastic-search サービスは setup の service_healthy を待っている
3. setup が完了してプロセスが終了すると、ヘルスチェックも停止してしまう
4. そのため elastic-search が永遠に setup の healthy 状態を待ち続ける

のようになっていたらしい。