### PR TITLE
patch: ユーザーの名前に関して、最大17文字の制限を設けた

### DIFF
--- a/database/schema.ts
+++ b/database/schema.ts
@@ -12,7 +12,7 @@ export const users = sqliteTable("user", {
   id: text("id")
     .primaryKey()
     .$defaultFn(() => crypto.randomUUID()),
-  name: text("name"),
+  name: text("name", { length: 17 }),
   email: text("email").unique(),
   emailVerified: integer("emailVerified", { mode: "timestamp_ms" }),
   image: text("image"),

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -12,6 +12,12 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       );
     }
+    if (name.length < 2 || name.length > 17) {
+      return NextResponse.json(
+        { error: "名前は2文字以上17文字以下で入力してください" },
+        { status: 400 },
+      );
+    }
     if (password !== confirmPassword) {
       return NextResponse.json(
         { error: "パスワードが一致しません" },

--- a/shared/src/drizzle/relations.ts
+++ b/shared/src/drizzle/relations.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm/relations";
-import { user, account, authenticator, players, games, session, tournamentMatches, tournaments, tournamentParticipants, userPassword } from "./schema";
+import { user, account, authenticator, session, userPassword, players, games, tournamentMatches, tournaments, tournamentParticipants } from "./schema";
 
 export const accountRelations = relations(account, ({one}) => ({
 	user: one(user, {
@@ -11,8 +11,9 @@ export const accountRelations = relations(account, ({one}) => ({
 export const userRelations = relations(user, ({many}) => ({
 	accounts: many(account),
 	authenticators: many(authenticator),
-	players: many(players),
 	sessions: many(session),
+	userPasswords: many(userPassword),
+	players: many(players),
 	tournamentMatches_winnerId: many(tournamentMatches, {
 		relationName: "tournamentMatches_winnerId_user_id"
 	}),
@@ -29,12 +30,25 @@ export const userRelations = relations(user, ({many}) => ({
 	tournaments_creatorId: many(tournaments, {
 		relationName: "tournaments_creatorId_user_id"
 	}),
-	userPasswords: many(userPassword),
 }));
 
 export const authenticatorRelations = relations(authenticator, ({one}) => ({
 	user: one(user, {
 		fields: [authenticator.userId],
+		references: [user.id]
+	}),
+}));
+
+export const sessionRelations = relations(session, ({one}) => ({
+	user: one(user, {
+		fields: [session.userId],
+		references: [user.id]
+	}),
+}));
+
+export const userPasswordRelations = relations(userPassword, ({one}) => ({
+	user: one(user, {
+		fields: [userPassword.userId],
 		references: [user.id]
 	}),
 }));
@@ -53,13 +67,6 @@ export const playersRelations = relations(players, ({one}) => ({
 export const gamesRelations = relations(games, ({many}) => ({
 	players: many(players),
 	tournamentMatches: many(tournamentMatches),
-}));
-
-export const sessionRelations = relations(session, ({one}) => ({
-	user: one(user, {
-		fields: [session.userId],
-		references: [user.id]
-	}),
 }));
 
 export const tournamentMatchesRelations = relations(tournamentMatches, ({one}) => ({
@@ -111,12 +118,5 @@ export const tournamentParticipantsRelations = relations(tournamentParticipants,
 	tournament: one(tournaments, {
 		fields: [tournamentParticipants.tournamentId],
 		references: [tournaments.id]
-	}),
-}));
-
-export const userPasswordRelations = relations(userPassword, ({one}) => ({
-	user: one(user, {
-		fields: [userPassword.userId],
-		references: [user.id]
 	}),
 }));

--- a/shared/src/drizzle/schema.ts
+++ b/shared/src/drizzle/schema.ts
@@ -33,6 +33,28 @@ export const authenticator = sqliteTable("authenticator", {
 	primaryKey({ columns: [table.credentialId, table.userId], name: "authenticator_credentialID_userId_pk"})
 ]);
 
+export const session = sqliteTable("session", {
+	sessionToken: text().primaryKey().notNull(),
+	userId: text().notNull().references(() => user.id, { onDelete: "cascade" } ),
+	expires: integer().notNull(),
+});
+
+export const userPassword = sqliteTable("user_password", {
+	userId: text("user_id").primaryKey().notNull().references(() => user.id, { onDelete: "cascade" } ),
+	passwordHash: text("password_hash").notNull(),
+	createdAt: integer("created_at").default(sql`(CURRENT_TIMESTAMP)`).notNull(),
+	updatedAt: integer("updated_at").default(sql`(CURRENT_TIMESTAMP)`).notNull(),
+});
+
+export const verificationToken = sqliteTable("verificationToken", {
+	identifier: text().notNull(),
+	token: text().notNull(),
+	expires: integer().notNull(),
+},
+(table) => [
+	primaryKey({ columns: [table.identifier, table.token], name: "verificationToken_identifier_token_pk"})
+]);
+
 export const games = sqliteTable("games", {
 	id: text().primaryKey().notNull(),
 	startedAt: integer("started_at").notNull(),
@@ -58,12 +80,6 @@ export const players = sqliteTable("players", {
 (table) => [
 	uniqueIndex("players_game_side_unique").on(table.gameId, table.side),
 ]);
-
-export const session = sqliteTable("session", {
-	sessionToken: text().primaryKey().notNull(),
-	userId: text().notNull().references(() => user.id, { onDelete: "cascade" } ),
-	expires: integer().notNull(),
-});
 
 export const tournamentMatches = sqliteTable("tournament_matches", {
 	id: text().primaryKey().notNull(),
@@ -106,30 +122,14 @@ export const tournaments = sqliteTable("tournaments", {
 	endedAt: integer("ended_at"),
 });
 
-export const userPassword = sqliteTable("user_password", {
-	userId: text("user_id").primaryKey().notNull().references(() => user.id, { onDelete: "cascade" } ),
-	passwordHash: text("password_hash").notNull(),
-	createdAt: integer("created_at").default(sql`(CURRENT_TIMESTAMP)`).notNull(),
-	updatedAt: integer("updated_at").default(sql`(CURRENT_TIMESTAMP)`).notNull(),
-});
-
 export const user = sqliteTable("user", {
 	id: text().primaryKey().notNull(),
-	name: text(),
+	name: text({ length: 17 }),
 	email: text(),
 	emailVerified: integer(),
 	image: text(),
 },
 (table) => [
 	uniqueIndex("user_email_unique").on(table.email),
-]);
-
-export const verificationToken = sqliteTable("verificationToken", {
-	identifier: text().notNull(),
-	token: text().notNull(),
-	expires: integer().notNull(),
-},
-(table) => [
-	primaryKey({ columns: [table.identifier, table.token], name: "verificationToken_identifier_token_pk"})
 ]);
 


### PR DESCRIPTION
このPull Requestでは、データベースおよびAPI層におけるスキーマの更新、バリデーションの改善、リファクタリングを行いました。

### スキーマの更新:
+ `user` テーブルの `name` フィールドに最大20文字の長さ制限を追加

### バリデーションの改善:
+ `register` API にて `name` フィールドが2文字以上17文字以下であることを検証
  - 対象ファイル: `frontend/src/app/api/auth/register/route.ts`
  

![image](https://github.com/user-attachments/assets/0011e2d9-a120-43ff-908c-e2ac47c53fbe)

