### PR TITLE
update: sessionの更新時刻を記録し、最後のアクティビティを大雑把に取得できるようなエンドポイントを作成した

### DIFF
--- a/database/schema.ts
+++ b/database/schema.ts
@@ -16,6 +16,7 @@ export const users = sqliteTable("user", {
   email: text("email").unique(),
   emailVerified: integer("emailVerified", { mode: "timestamp_ms" }),
   image: text("image"),
+  lastActivity: integer("last_activity", { mode: "timestamp_ms" })
 });
 
 export const userPasswords = sqliteTable(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,13 +11,14 @@
     "introspect": "drizzle-kit introspect"
   },
   "dependencies": {
-    "@ft-transcendence/shared": "file:../shared",
     "@auth/drizzle-adapter": "^1.9.1",
     "@aws-sdk/client-s3": "^3.812.0",
     "@aws-sdk/s3-request-presigner": "^3.812.0",
+    "@ft-transcendence/shared": "file:../shared",
     "@libsql/client": "^0.15.7",
     "@types/uuid": "^10.0.0",
     "bcryptjs": "^3.0.2",
+    "date-fns-tz": "^3.2.0",
     "drizzle-orm": "^0.43.1",
     "next": "15.3.1",
     "next-auth": "^4.24.11",

--- a/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -6,6 +6,7 @@ import * as jwt from "next-auth/jwt";
 import NextAuth from "next-auth/next";
 import CredentialsProvider from "next-auth/providers/credentials";
 import GoogleProvider from "next-auth/providers/google";
+import { updateLastActivity } from "@/api/auth/lastActivityService";
 
 export const authOptions: NextAuthOptions = {
   debug: true,
@@ -62,6 +63,7 @@ export const authOptions: NextAuthOptions = {
       if (session.user) {
         session.user.id = user.id;
         session.user.provider = (await getProvider(user.id)) ?? "credentials";
+        await updateLastActivity(user.id);
       }
       return session;
     },

--- a/frontend/src/app/api/auth/last-activity/route.ts
+++ b/frontend/src/app/api/auth/last-activity/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { format, toZonedTime } from "date-fns-tz";
+import { getServerSession } from "next-auth/next";
+
+import { getLastActivity } from "../lastActivityService";
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession();
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get("userId") || session.user.id;
+
+    const lastActivity = await getLastActivity(userId);
+    return NextResponse.json(
+      {
+        userId,
+        lastActivity,
+        lastActivityDate: lastActivity
+          ? format(
+              toZonedTime(new Date(lastActivity), "Asia/Tokyo"),
+              "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+              { timeZone: "Asia/Tokyo" },
+            )
+          : null,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("Failed to get last activity:", error);
+    return NextResponse.json(
+      { error: "最終アクティビティの取得に失敗しました" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/src/app/api/auth/lastActivityService.ts
+++ b/frontend/src/app/api/auth/lastActivityService.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { db } from "@/api/db";
+import { user } from "@ft-transcendence/shared";
+import { eq } from "drizzle-orm";
+
+const lastUpdateCache = new Map<string, number>();
+
+export async function updateLastActivity(userId: string): Promise<void> {
+  const currentTime = new Date().getTime();
+  const lastUpdate = lastUpdateCache.get(userId) || 0;
+
+  // 2分以上経過している場合のみ更新
+  try {
+    if (currentTime - lastUpdate > 2 * 60 * 1000) {
+      await db
+        .update(user)
+        .set({ lastActivity: new Date(currentTime).getTime() })
+        .where(eq(user.id, userId));
+      lastUpdateCache.set(userId, currentTime);
+    }
+  } catch (error) {
+    console.error(`Failed to update last activity for user ${userId}:`, error);
+  }
+}
+
+export async function getLastActivity(userId: string): Promise<number | null> {
+  try {
+    // First check the cache
+    const cachedLastActivity = lastUpdateCache.get(userId);
+    if (cachedLastActivity !== undefined) {
+      return cachedLastActivity;
+    }
+    const userRecord = await db
+      .select()
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1)
+      .get();
+    if (userRecord && userRecord.lastActivity) {
+      lastUpdateCache.set(userId, userRecord.lastActivity);
+      return userRecord.lastActivity;
+    }
+    return null;
+  } catch (error) {
+    console.error(`Failed to get last activity for user ${userId}:`, error);
+    return null;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,12 @@ importers:
       bcryptjs:
         specifier: ^3.0.2
         version: 3.0.2
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@4.1.0)
       drizzle-orm:
         specifier: ^0.43.1
         version: 0.43.1(@libsql/client@0.15.7)
@@ -2649,6 +2655,14 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -7225,6 +7239,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns-tz@3.2.0(date-fns@4.1.0):
+    dependencies:
+      date-fns: 4.1.0
+
+  date-fns@4.1.0: {}
 
   debug@3.2.7:
     dependencies:

--- a/shared/src/drizzle/relations.ts
+++ b/shared/src/drizzle/relations.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm/relations";
-import { user, account, authenticator, session, userPassword, players, games, tournamentMatches, tournaments, tournamentParticipants } from "./schema";
+import { user, account, authenticator, players, games, session, tournamentMatches, tournaments, tournamentParticipants, userPassword } from "./schema";
 
 export const accountRelations = relations(account, ({one}) => ({
 	user: one(user, {
@@ -11,9 +11,8 @@ export const accountRelations = relations(account, ({one}) => ({
 export const userRelations = relations(user, ({many}) => ({
 	accounts: many(account),
 	authenticators: many(authenticator),
-	sessions: many(session),
-	userPasswords: many(userPassword),
 	players: many(players),
+	sessions: many(session),
 	tournamentMatches_winnerId: many(tournamentMatches, {
 		relationName: "tournamentMatches_winnerId_user_id"
 	}),
@@ -30,25 +29,12 @@ export const userRelations = relations(user, ({many}) => ({
 	tournaments_creatorId: many(tournaments, {
 		relationName: "tournaments_creatorId_user_id"
 	}),
+	userPasswords: many(userPassword),
 }));
 
 export const authenticatorRelations = relations(authenticator, ({one}) => ({
 	user: one(user, {
 		fields: [authenticator.userId],
-		references: [user.id]
-	}),
-}));
-
-export const sessionRelations = relations(session, ({one}) => ({
-	user: one(user, {
-		fields: [session.userId],
-		references: [user.id]
-	}),
-}));
-
-export const userPasswordRelations = relations(userPassword, ({one}) => ({
-	user: one(user, {
-		fields: [userPassword.userId],
 		references: [user.id]
 	}),
 }));
@@ -67,6 +53,13 @@ export const playersRelations = relations(players, ({one}) => ({
 export const gamesRelations = relations(games, ({many}) => ({
 	players: many(players),
 	tournamentMatches: many(tournamentMatches),
+}));
+
+export const sessionRelations = relations(session, ({one}) => ({
+	user: one(user, {
+		fields: [session.userId],
+		references: [user.id]
+	}),
 }));
 
 export const tournamentMatchesRelations = relations(tournamentMatches, ({one}) => ({
@@ -118,5 +111,12 @@ export const tournamentParticipantsRelations = relations(tournamentParticipants,
 	tournament: one(tournaments, {
 		fields: [tournamentParticipants.tournamentId],
 		references: [tournaments.id]
+	}),
+}));
+
+export const userPasswordRelations = relations(userPassword, ({one}) => ({
+	user: one(user, {
+		fields: [userPassword.userId],
+		references: [user.id]
 	}),
 }));

--- a/shared/src/drizzle/schema.ts
+++ b/shared/src/drizzle/schema.ts
@@ -33,28 +33,6 @@ export const authenticator = sqliteTable("authenticator", {
 	primaryKey({ columns: [table.credentialId, table.userId], name: "authenticator_credentialID_userId_pk"})
 ]);
 
-export const session = sqliteTable("session", {
-	sessionToken: text().primaryKey().notNull(),
-	userId: text().notNull().references(() => user.id, { onDelete: "cascade" } ),
-	expires: integer().notNull(),
-});
-
-export const userPassword = sqliteTable("user_password", {
-	userId: text("user_id").primaryKey().notNull().references(() => user.id, { onDelete: "cascade" } ),
-	passwordHash: text("password_hash").notNull(),
-	createdAt: integer("created_at").default(sql`(CURRENT_TIMESTAMP)`).notNull(),
-	updatedAt: integer("updated_at").default(sql`(CURRENT_TIMESTAMP)`).notNull(),
-});
-
-export const verificationToken = sqliteTable("verificationToken", {
-	identifier: text().notNull(),
-	token: text().notNull(),
-	expires: integer().notNull(),
-},
-(table) => [
-	primaryKey({ columns: [table.identifier, table.token], name: "verificationToken_identifier_token_pk"})
-]);
-
 export const games = sqliteTable("games", {
 	id: text().primaryKey().notNull(),
 	startedAt: integer("started_at").notNull(),
@@ -80,6 +58,12 @@ export const players = sqliteTable("players", {
 (table) => [
 	uniqueIndex("players_game_side_unique").on(table.gameId, table.side),
 ]);
+
+export const session = sqliteTable("session", {
+	sessionToken: text().primaryKey().notNull(),
+	userId: text().notNull().references(() => user.id, { onDelete: "cascade" } ),
+	expires: integer().notNull(),
+});
 
 export const tournamentMatches = sqliteTable("tournament_matches", {
 	id: text().primaryKey().notNull(),
@@ -122,12 +106,29 @@ export const tournaments = sqliteTable("tournaments", {
 	endedAt: integer("ended_at"),
 });
 
+export const userPassword = sqliteTable("user_password", {
+	userId: text("user_id").primaryKey().notNull().references(() => user.id, { onDelete: "cascade" } ),
+	passwordHash: text("password_hash").notNull(),
+	createdAt: integer("created_at").default(sql`(CURRENT_TIMESTAMP)`).notNull(),
+	updatedAt: integer("updated_at").default(sql`(CURRENT_TIMESTAMP)`).notNull(),
+});
+
+export const verificationToken = sqliteTable("verificationToken", {
+	identifier: text().notNull(),
+	token: text().notNull(),
+	expires: integer().notNull(),
+},
+(table) => [
+	primaryKey({ columns: [table.identifier, table.token], name: "verificationToken_identifier_token_pk"})
+]);
+
 export const user = sqliteTable("user", {
 	id: text().primaryKey().notNull(),
 	name: text({ length: 17 }),
 	email: text(),
 	emailVerified: integer(),
 	image: text(),
+	lastActivity: integer("last_activity"),
 },
 (table) => [
 	uniqueIndex("user_email_unique").on(table.email),


### PR DESCRIPTION
> [!WARNING]
> DBスキーマを変更しているので注意 

ログインが必要なページにアクセスすると、そのユーザーのsessionの検証が行われる。
その際に、アクティビティのタイムスタンプとしてDBに記録するようにした。

2分以内のsesionの更新はDBの書き込み頻度を減らすために無視している。

---

この情報は`/api/auth/last-activity`に対してGETメソッドを使用することで
「そのユーザーの最後のアクティビティ」の情報を得ることができる。

使用例
![image](https://github.com/user-attachments/assets/10941940-4b7b-49c4-b7f0-d2a7c5977626)
